### PR TITLE
Remove colon in bot prefix due to change in slack

### DIFF
--- a/bots/bot.go
+++ b/bots/bot.go
@@ -336,7 +336,7 @@ func (bot *Bot) Run() error {
 				continue
 			}
 
-			botprefix := fmt.Sprintf("<@%s>:", bot.User.ID)
+			botprefix := fmt.Sprintf("<@%s>", bot.User.ID)
 
 			// if has prefix, run command after
 			if strings.HasPrefix(msg.Text, botprefix) {


### PR DESCRIPTION
Slack changed the way username auto-completes are done and no longer includes a `:`.

This change removes it from the listener so the bot can be addressed easily (without backspacing twice).
